### PR TITLE
Delete new line code when it is included in token read from secret.txt.

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -9,6 +9,7 @@ var latex = {};
 var fs = require('fs');
 fs.readFile('secret.txt','utf8',function (err, data) {
     global.token=data;
+    global.token = global.token.replace(/[\n\r]/g,"");
     getWebSocket();
 });
 


### PR DESCRIPTION
Add the code to delete global.token's new line code. When I load token from secret.txt, there is new line code at end of file even if there is no new line code and it becomes error.
