### PR TITLE
Add option to host on Heroku.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+bot: node bot.js

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm install request
 npm install websocket
 ```
 
-Create a secret.txt file in the bot directory and put your slack token in it
+Set the `SLACK_TOKEN` env var or create a secret.txt file in the bot directory and put your slack token in it.
 
 Start bot by running `node bot.js` or `nodejs bot.js`
 

--- a/bot.js
+++ b/bot.js
@@ -7,13 +7,19 @@ var message="";
 var i = 0;
 var latex = {};
 var fs = require('fs');
-fs.readFile('secret.txt','utf8',function (err, data) {
-    global.token=data;
-    global.token = global.token.replace(/[\n\r]/g,"");
-    getWebSocket();
-});
 
-//gets the websocket url 
+global.token = process.env.SLACK_TOKEN;
+if (global.token) {
+    getWebSocket();
+} else {
+    fs.readFile('secret.txt','utf8',function (err, data) {
+        global.token=data;
+        global.token = global.token.replace(/[\n\r]/g,"");
+        getWebSocket();
+    });
+}
+
+//gets the websocket url
 function getWebSocket(){
     request('https://slack.com/api/rtm.start?token='+global.token+'&pretty=1', function (error, response, body) {
          //console.log(response.url);
@@ -72,7 +78,7 @@ function postLatex(channel,text) {
     var urlBase= 'http://latex.codecogs.com/png.latex?%5Cdpi%7B300%7D%20'+encodeURIComponent(text);
 
     var dURL = "https://slack.com/api/chat.postMessage?token="+global.token+"&channel="+channel+"&text=%20&attachments=%5B%7B%22fallback%22%3A%22.%22%2C%22color%22%3A%20%22%2336a64f%22%2C%22image_url%22%3A%22" + encodeURIComponent(urlBase)+"%22%7D%5D&pretty=1";
-    
+
     request(dURL, function (error, response, body) {
          //console.log(response.url);
          if (!error && response.statusCode == 200) {
@@ -88,7 +94,7 @@ function handleMessage(mObj){
     console.log(mObj.type+"\n");
 
     if(mObj.type==='message'){
-        
+
         console.log("\t"+mObj.channel+"\n");
         console.log("\t"+mObj.user+"\n");
         console.log("\t"+mObj.text+"\n");
@@ -103,7 +109,7 @@ function handleMessage(mObj){
 
             console.log('Converting to latex: ' + mObj.text);
         }
-        
+
         if(mObj.text==='..startLatex') {
             latex[mObj.user+mObj.channel]=true;
             console.log('Enable latex for ' + mObj.user+mObj.channel);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "slacklatex",
+  "version": "1.0.0",
+  "description": "Bot to convert LateX code in messages into images.",
+  "main": "bot.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sand500/SlackLateX.git"
+  },
+  "author": "",
+  "license": "Unlicense",
+  "bugs": {
+    "url": "https://github.com/sand500/SlackLateX/issues"
+  },
+  "homepage": "https://github.com/sand500/SlackLateX#readme",
+  "dependencies": {
+    "fs": "0.0.2",
+    "request": "^2.73.0",
+    "websocket": "^1.0.23"
+  }
+}


### PR DESCRIPTION
Why:
- It's a nice way to quickly get up and running for free.

This change addresses the need by:
- Add a Procfile.
- Add a package.json with required dependencies.
- Add option to set token via an ENV var.
